### PR TITLE
Improve Markdown formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Graphic acceleration (Aero) must be enabled.
 
 - Press <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>H</kbd> to Halt the program immediately
 - Press <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>N</kbd> to toggle color inversion (mnemonic: Night vision :))
-- Press <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>F1</kbd>-to-<kbd>F10</kbd> to switch between inversion modes:
+- Press <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>F1</kbd>-to-<kbd>F11</kbd> to switch between inversion modes:
 	* <kbd>F1</kbd>: standard inversion
 	* <kbd>F2</kbd>: smart inversion1 - theoretical optimal transformation (but ugly desaturated pure colors)
 	* <kbd>F3</kbd>: smart inversion2 - high saturation, good pure colors

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ swapping blacks and whites while keeping colors (about) the sames.
 You can now configure the color effects manually via a configuration file.
 You can also configure the hot keys for every actions, using the same configuration file.
 
-A basic web api is part of NegativeScreen >= 2.5
+A basic web api is part of NegativeScreen >= 2.5.
 It is disabled by default. When enabled, it listens by default on port 8990, localhost only.
 See the configuration file to enable the api or change the listening uri...
 

--- a/README.md
+++ b/README.md
@@ -57,20 +57,20 @@ Graphic acceleration (Aero) must be enabled.
 
 ## Default controls
 
-- Press Win+Alt+H to Halt the program immediately
-- Press Win+Alt+N to toggle color inversion (mnemonic: Night vision :))
-- Press Win+Alt+F1-to-F10 to switch between inversion modes:
-	* F1: standard inversion
-	* F2: smart inversion1 - theoretical optimal transformation (but ugly desaturated pure colors)
-	* F3: smart inversion2 - high saturation, good pure colors
-	* F4: smart inversion3 - overall desaturated, yellows and blues plain bad. actually relaxing and very usable
-	* F5: smart inversion4 - high saturation. yellows and blues  plain bad. actually quite readable
-	* F6: smart inversion5 - not so readable. good colors. (CMY colors a bit desaturated, still more saturated than normal)
-	* F7: negative sepia
-	* F8: negative gray scale
-	* F9: negative red
-	* F10: red
-	* F11: grayscale
+- Press <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>H</kbd> to Halt the program immediately
+- Press <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>N</kbd> to toggle color inversion (mnemonic: Night vision :))
+- Press <kbd>Win</kbd>+<kbd>Alt</kbd>+<kbd>F1</kbd>-to-<kbd>F10</kbd> to switch between inversion modes:
+	* <kbd>F1</kbd>: standard inversion
+	* <kbd>F2</kbd>: smart inversion1 - theoretical optimal transformation (but ugly desaturated pure colors)
+	* <kbd>F3</kbd>: smart inversion2 - high saturation, good pure colors
+	* <kbd>F4</kbd>: smart inversion3 - overall desaturated, yellows and blues plain bad. actually relaxing and very usable
+	* <kbd>F5</kbd>: smart inversion4 - high saturation. yellows and blues  plain bad. actually quite readable
+	* <kbd>F6</kbd>: smart inversion5 - not so readable. good colors. (CMY colors a bit desaturated, still more saturated than normal)
+	* <kbd>F7</kbd>: negative sepia
+	* <kbd>F8</kbd>: negative gray scale
+	* <kbd>F9</kbd>: negative red
+	* <kbd>F10</kbd>: red
+	* <kbd>F11</kbd>: grayscale
 
 
 ## Configuration file

--- a/README.md
+++ b/README.md
@@ -57,10 +57,9 @@ Graphic acceleration (Aero) must be enabled.
 
 ## Default controls
 
--Press Win+Alt+H to Halt the program immediately
--Press Win+Alt+N to toggle color inversion (mnemonic: Night vision :))
-
--Press Win+Alt+F1-to-F10 to switch between inversion modes:
+- Press Win+Alt+H to Halt the program immediately
+- Press Win+Alt+N to toggle color inversion (mnemonic: Night vision :))
+- Press Win+Alt+F1-to-F10 to switch between inversion modes:
 	* F1: standard inversion
 	* F2: smart inversion1 - theoretical optimal transformation (but ugly desaturated pure colors)
 	* F3: smart inversion2 - high saturation, good pure colors


### PR DESCRIPTION
The Markdown formatting of the lists in the README are currently broken, and don't display as a list at all, but rather a jumble of text. This patch fixes that. See individual commits for details.